### PR TITLE
Minor spelling fix. Developpers -> Developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Targets, Email Templates and Campaign are the minimum required to run a basic ph
 
 
 
-# Developpers
+# Developers
 
 ## To participate to the project :
 


### PR DESCRIPTION
This change simply fixes the spelling of one of the words in the README.