### PR TITLE
Add django interpretation in email template

### DIFF
--- a/phishing/helpers.py
+++ b/phishing/helpers.py
@@ -8,6 +8,8 @@ import requests
 from django.core.mail import EmailMultiAlternatives
 from django.core.mail.backends.smtp import EmailBackend
 from django.core.urlresolvers import reverse
+from django.template import Context
+from django.template import Template
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy as _
 from pyshorteners import Shortener
@@ -220,16 +222,12 @@ def replace_template_vars(template, campaign=None, target=None,
     :param email_template: `.models.EmailTemplate`
     :return: content with value
     """
+    vars_context={}
     for var in get_template_vars(campaign, target, email_template):
-        names = (
-            '{{%s}}' % var['name'],
-            '{{ %s }}' % var['name']
-        )
-        value = var['value'] or ''
-        for name in names:
-            template = template.replace(name, value)
+        vars_context[var['name']]=var['value']
 
-    return template
+    context = Context(vars_context)
+    return Template(template).render(context)
 
 
 def start_campaign(campaign):

--- a/phishing/helpers.py
+++ b/phishing/helpers.py
@@ -222,11 +222,8 @@ def replace_template_vars(template, campaign=None, target=None,
     :param email_template: `.models.EmailTemplate`
     :return: content with value
     """
-    vars_context={}
-    for var in get_template_vars(campaign, target, email_template):
-        vars_context[var['name']]=var['value']
-
-    context = Context(vars_context)
+    vars = get_template_vars(campaign, target, email_template)
+    context = Context({v['name']: v['value'] for v in vars })
     return Template(template).render(context)
 
 

--- a/phishing/tests/signal.py
+++ b/phishing/tests/signal.py
@@ -100,9 +100,9 @@ class EmailTemplateSignalTestCase(TestCase, SearchListMixin):
         var_data = self.get('email')
         self.assertIsNone(var_data)
 
-        # test replace
+        # test render
         content = replace_template_vars('{{ email }}')
-        self.assertEqual(content, '{{ email }}')
+        self.assertEqual(content, '')
 
         # clean
         self.assertTrue(make_template_vars.disconnect(handler))

--- a/phishing/tests/template.py
+++ b/phishing/tests/template.py
@@ -4,7 +4,8 @@ from datetime import datetime
 from django.test import TestCase
 from django.urls import reverse
 
-from phishing.helpers import minimize_url, get_template_vars
+from phishing.helpers import minimize_url, get_template_vars, \
+    replace_template_vars
 from phishing.models import Target, TargetGroup, EmailTemplate
 from phishing.tests.constant import FIXTURE_PATH
 
@@ -240,3 +241,21 @@ class TemplateTestCase(TestCase):
         self.assertEqual(resp.status_code, 200)
 
         # TODO: Test user that is not admin
+
+    def test_security_template(self):
+        # test render
+        content = replace_template_vars('{{ request }}')
+        print(content)
+        self.assertEqual(content, '')
+
+        # test render
+        content = replace_template_vars("{% include 'phishing/email/tracker_image.html' %}")
+        self.assertEqual(content, '')
+
+        # test load
+        content = replace_template_vars('{% load log %}{% get_admin_log 10 as admin_log %}{{ admin_log }}')
+        self.assertEqual(content, '')
+
+        # list load avalible
+        content = replace_template_vars('{% load fghdfhfghd %}')
+        self.assertEqual(content, '')


### PR DESCRIPTION
Before accepting this pull request, it's necessary to find a way to prevent "Server Side Template Injection" .

The following test need to be passed : 

+        # test load
+        content = replace_template_vars('{% load log %}{% get_admin_log 10 as admin_log %}{{ admin_log }}')
+        self.assertEqual(content, '')