### PR TITLE
Migrate from debian to alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,18 @@
-FROM python:3-onbuild
+FROM python:3-alpine
 
-# To handle buildable attachments
-RUN apt-get update && apt-get install -y zip unzip
+# To handle buildable attachments and compile cchardet
+RUN apk update && apk add --no-cache zip unzip g++ libc-dev
+
+# Do like debian "onbuild" versions
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+COPY requirements.txt /usr/src/app/
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . /usr/src/app
 
 # prepare django
 RUN python manage.py makemigrations
 RUN python manage.py collectstatic --noinput
-
 
 # start django
 EXPOSE 8000


### PR DESCRIPTION
Debian image seems to have a lot of vulnerability according to Anchore.io. A migration to alpine seems to be a better choice.